### PR TITLE
Fix missing logo on GitHub Pages

### DIFF
--- a/data/content.json
+++ b/data/content.json
@@ -164,7 +164,7 @@
     "hours": "Monday - Saturday: 9:00 AM - 8:00 PM"
   },
   "navigation": {
-    "logo": "/word-and-wonder-logo.svg",
+    "logo": "/websiteEnglish/word-and-wonder-logo.svg",
     "menuItems": [
       {
         "id": "about",

--- a/lib/content-config.ts
+++ b/lib/content-config.ts
@@ -303,7 +303,7 @@ export const defaultContent: SiteContent = {
     hours: "Monday - Saturday: 9:00 AM - 8:00 PM"
   },
   navigation: {
-    logo: "/word-and-wonder-logo.svg",
+    logo: "/websiteEnglish/word-and-wonder-logo.svg",
     menuItems: [
       { id: "about", label: "About", href: "#about", order: 1 },
       { id: "services", label: "Services", href: "#services", order: 2 },


### PR DESCRIPTION
## Summary
- reference the logo with the GitHub Pages base path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845cfb403c483288335610173b44e4c